### PR TITLE
feat: optimize polyfills

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,12 @@
 {
-  "presets": ["@babel/preset-env"],
-  "plugins": ["@babel/plugin-transform-object-assign", "@babel/plugin-syntax-dynamic-import", "webpack-async-module-name"]
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "entry",
+        "corejs": 3
+      }
+    ]
+  ],
+  "plugins": ["@babel/plugin-syntax-dynamic-import", "webpack-async-module-name"]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 		"@babel/core": "^7.4.4",
 		"@babel/parser": "^7.3.4",
 		"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-		"@babel/plugin-transform-object-assign": "^7.2.0",
 		"@babel/preset-env": "^7.4.4",
 		"acorn": "^6.1.1",
 		"acorn-dynamic-import": "^4.0.0",
@@ -26,7 +25,6 @@
 		"babel-plugin-webpack-async-module-name": "^1.0.2",
 		"clean-webpack-plugin": "^2.0.1",
 		"copy-webpack-plugin": "^4.6.0",
-		"core-js": "^3.0.0",
 		"css-loader": "^2.1.0",
 		"eslint": "^4.19.1",
 		"eslint-loader": "^2.1.1",
@@ -81,5 +79,9 @@
 	"browserslist": [
 		"> 1%",
 		"last 2 versions"
-	]
+	],
+	"dependencies": {
+		"core-js": "^3.0.1",
+		"regenerator-runtime": "^0.13.2"
+	}
 }

--- a/src/libs.js
+++ b/src/libs.js
@@ -1,5 +1,6 @@
 // JS polyfill
-import 'core-js';
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 // NPM packages
 import 'magnific-popup/dist/jquery.magnific-popup.min';


### PR DESCRIPTION
@babel/plugin-transform-object-assign нам не нужен, если используем core-js полифиллы. Плюс с версии babel@7.4 есть рекомендации по подключению этой библиотеки с preset-env.
Теоретически у нас могут быть какие-то проекты, где не понадобится поддержка ie. Там мы сможем отредоктировать browserslits и уменьшить итоговый размер бандла, т.к. babel возьмет только нужные полифиллы из core.js